### PR TITLE
Replace checkmark emoji.

### DIFF
--- a/src/awry.md
+++ b/src/awry.md
@@ -14,11 +14,11 @@ exist even fewer compile on rust stable.
 
 | Name       | Native Rust | Compiles on stable | 1.0 maturity |
 |------------|-------------|--------------------|--------------|
-| [RTIC]     | 🗸           | 🗸                  | ❌           |
-| [R3]       | 🗸           | ❌                 | ❌           |
-| [drone]    | 🗸           | ❌                 | ❌           |
-| [Tock]     | 🗸           | ❌                 | ❌           |
-| [zephyr]   | ❌          | 🗸                  | ❌           |
+| [RTIC]     | 👍          | 👍                 | ❌           |
+| [R3]       | 👍          | ❌                 | ❌           |
+| [drone]    | 👍          | ❌                 | ❌           |
+| [Tock]     | 👍          | ❌                 | ❌           |
+| [zephyr]   | ❌          | 👍                 | ❌           |
 | [freertos] | ❌          | Partial            | ❌           |
 
 [RTIC]: https://rtic.rs/0.5/book/en/


### PR DESCRIPTION
The checkmark does not render on Android 11 (Firefox and Chrome).

![image](https://user-images.githubusercontent.com/7845120/116012832-d3870d00-a5e1-11eb-8aaf-ac16d5b51333.png)
