### PR TITLE
RIOT builds on stable on all platforms

### DIFF
--- a/src/awry.md
+++ b/src/awry.md
@@ -28,7 +28,7 @@ benefit RTOS development:
 | [freertos] | ❌          | Partial            | MIT                        | en          |
 | [hubris]   | ✅          | ❌                 | MPL-2.0                    | en          |
 | [R3]       | ✅          | ❌                 | MIT OR Apache-2.0          | en          |
-| [RIOT-OS]  | ❌          | Partial            | LGPL-2.1                   | en          |
+| [RIOT-OS]  | ❌          | ✅                 | LGPL-2.1                   | en          |
 | [RTIC]     | ✅          | ✅                 | MIT OR Apache-2.0          | en, ru      |
 | [Tock]     | ✅          | ❌                 | MIT OR Apache-2.0          | en          |
 | [tornado]  | ✅          | ❌                 | Apache-2.0 OR MulanPSL-2.0 | zh          |


### PR DESCRIPTION
Since [17805] (part of the upcoming 2022.04 release), RIOT's test case for Rust is built on stable on all platforms.

[17805]: https://github.com/RIOT-OS/RIOT/pull/17805

Some features of RIOT (eg. the CoAP wrappers, which implement traits of a library that is nightly-only until GATs arrive) are nightly still, but I think that all platforms being tested with stable justifies setting this tick mark.